### PR TITLE
Add multiple quote APIs with fallback support

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,37 @@
   </div>
 
   <script>
-    const url = "https://programming-quotes-api.azurewebsites.net/api/quotes/random";
+    // Multiple API endpoints for reliability
+    const apiEndpoints = [
+      "https://api.quotable.io/random",
+      "https://programming-quotes-api.azurewebsites.net/api/quotes/random",
+      "https://zenquotes.io/api/random"
+    ];
+
+    // Fallback quotes in case all APIs fail
+    const fallbackQuotes = [
+      {
+        en: "The best way to predict the future is to invent it.",
+        author: "Alan Kay"
+      },
+      {
+        en: "Code is like humor. When you have to explain it, it's bad.",
+        author: "Cory House"
+      },
+      {
+        en: "Programming isn't about what you know; it's about what you can figure out.",
+        author: "Chris Pine"
+      },
+      {
+        en: "The only way to learn a new programming language is by writing programs in it.",
+        author: "Dennis Ritchie"
+      },
+      {
+        en: "Talk is cheap. Show me the code.",
+        author: "Linus Torvalds"
+      }
+    ];
+
 const data = document.getElementById("data");
 const btn = document.getElementById("btn");
 const prevBtn = document.getElementById("prevBtn");
@@ -92,19 +122,88 @@ const author = document.getElementById("author");
 
 let history = [];
 let currentQuote = null;
+let currentApiIndex = 0;
 
-function fetchQuote() {
-  fetch(url)
-    .then(response => response.json())
-    .then(quote => {
-      if (currentQuote) history.push(currentQuote);
-      currentQuote = quote;
-      updateUI(quote);
-      if (history.length > 0) prevBtn.classList.remove("hidden");
-    })
-    .catch(err => {
-      console.error("Error fetching quote:", err);
-    });
+async function fetchQuote() {
+  // Show loading state
+  btn.textContent = "Loading...";
+  btn.disabled = true;
+  
+  let quote = null;
+  let success = false;
+  
+  // Try each API endpoint
+  for (let i = 0; i < apiEndpoints.length && !success; i++) {
+    try {
+      console.log(`Trying API: ${apiEndpoints[currentApiIndex]}`);
+      
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+      
+      const response = await fetch(apiEndpoints[currentApiIndex], {
+        signal: controller.signal,
+        headers: {
+          'Accept': 'application/json'
+        }
+      });
+      
+      clearTimeout(timeoutId);
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      
+      const result = await response.json();
+      
+      // Handle different API response formats
+      if (apiEndpoints[currentApiIndex].includes('quotable.io')) {
+        quote = {
+          en: result.content,
+          author: result.author
+        };
+      } else if (apiEndpoints[currentApiIndex].includes('zenquotes.io')) {
+        quote = {
+          en: result[0].q,
+          author: result[0].a
+        };
+      } else {
+        // Programming quotes API format
+        quote = {
+          en: result.en || result.quote,
+          author: result.author
+        };
+      }
+      
+      if (quote && quote.en && quote.author) {
+        success = true;
+        console.log("Successfully fetched quote from API");
+      } else {
+        throw new Error("Invalid quote format");
+      }
+      
+    } catch (err) {
+      console.warn(`API ${currentApiIndex + 1} failed:`, err.message);
+      currentApiIndex = (currentApiIndex + 1) % apiEndpoints.length;
+    }
+  }
+  
+  // If all APIs fail, use fallback
+  if (!success) {
+    console.log("All APIs failed, using fallback quote");
+    quote = fallbackQuotes[Math.floor(Math.random() * fallbackQuotes.length)];
+  }
+  
+  // Update UI
+  if (quote) {
+    if (currentQuote) history.push(currentQuote);
+    currentQuote = quote;
+    updateUI(quote);
+    if (history.length > 0) prevBtn.classList.remove("hidden");
+  }
+  
+  // Reset button
+  btn.textContent = "New Quote";
+  btn.disabled = false;
 }
 
 function updateUI(quote) {


### PR DESCRIPTION
Enhanced the quote fetching logic to use multiple API endpoints for improved reliability. Added fallback quotes to display if all APIs fail, and updated the UI handling to support different API response formats and loading states.


Kindly Accept the Pull Request and Merge it Under Hacktoberfest 2025 and don't forget t add labels for Hacktoberfest-Accepted and Hacktoberfest